### PR TITLE
Improvements on Unit Tests for Community, fixed bugs in GetCommunitiesByPublicityViewController and See Post functionality

### DIFF
--- a/practiceapp/src/main/java/com/practiceapp/practiceapp/controller/views/GetCommunitiesByPublicityViewController.java
+++ b/practiceapp/src/main/java/com/practiceapp/practiceapp/controller/views/GetCommunitiesByPublicityViewController.java
@@ -9,7 +9,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
 
 
 @Controller
@@ -49,12 +48,10 @@ public class GetCommunitiesByPublicityViewController {
 
 
     @RequestMapping(path = "/search",method = RequestMethod.POST)
-    public String submitForm(@ModelAttribute("community") CommunityEntity communityEntity) {
+    public String submitForm(@ModelAttribute("community") CommunityEntity communityEntity, RedirectAttributes redirectAttributes) {
         Boolean publicity = communityEntity.isPublicity();
-        RedirectAttributes redirectAttributes = new RedirectAttributesModelMap();
+
         redirectAttributes.addAttribute("public", publicity);
         return "redirect:/home/communities/";
     }
-
-
 }

--- a/practiceapp/src/main/java/com/practiceapp/practiceapp/controller/views/GetPostsViewController.java
+++ b/practiceapp/src/main/java/com/practiceapp/practiceapp/controller/views/GetPostsViewController.java
@@ -1,5 +1,6 @@
 package com.practiceapp.practiceapp.controller.views;
 
+import com.practiceapp.practiceapp.entity.CommunityEntity;
 import com.practiceapp.practiceapp.entity.PostEntity;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -27,7 +28,12 @@ public class GetPostsViewController {
     @RequestMapping(path = "/{community_name}",method = RequestMethod.GET)
     public String showPostsByCommunityName(Model model, @PathVariable("community_name") String community_name){  //TEST AFTER POSTS ADDED!
 
-        List<PostEntity> posts = restTemplate.getForObject(base_url + target_url + "/" + community_name, List.class);
+        System.out.println("NEREDE");
+        System.out.println("NEREDE");
+        System.out.println("NEREDE");
+
+        PostEntity[] posts = restTemplate.getForObject(base_url + target_url + "/" + community_name, PostEntity[].class);
+
         JSONArray rows = new JSONArray();
         for (PostEntity post: posts) {
             JSONObject row = new JSONObject()
@@ -38,7 +44,9 @@ public class GetPostsViewController {
 
             rows.put(row);
         }
-        model.addAttribute("posts", rows);
+
+        System.out.println(rows);
+        model.addAttribute("rows", rows.toString());
         return "posts";
     }
 

--- a/practiceapp/src/main/java/com/practiceapp/practiceapp/controller/views/GetPostsViewController.java
+++ b/practiceapp/src/main/java/com/practiceapp/practiceapp/controller/views/GetPostsViewController.java
@@ -43,7 +43,7 @@ public class GetPostsViewController {
             rows.put(row);
         }
 
-        System.out.println(rows);
+        
         model.addAttribute("rows", rows.toString());
         return "posts";
     }

--- a/practiceapp/src/main/java/com/practiceapp/practiceapp/controller/views/GetPostsViewController.java
+++ b/practiceapp/src/main/java/com/practiceapp/practiceapp/controller/views/GetPostsViewController.java
@@ -28,9 +28,7 @@ public class GetPostsViewController {
     @RequestMapping(path = "/{community_name}",method = RequestMethod.GET)
     public String showPostsByCommunityName(Model model, @PathVariable("community_name") String community_name){  //TEST AFTER POSTS ADDED!
 
-        System.out.println("NEREDE");
-        System.out.println("NEREDE");
-        System.out.println("NEREDE");
+       
 
         PostEntity[] posts = restTemplate.getForObject(base_url + target_url + "/" + community_name, PostEntity[].class);
 

--- a/practiceapp/src/main/resources/templates/communities.html
+++ b/practiceapp/src/main/resources/templates/communities.html
@@ -24,8 +24,6 @@
     const data = /*[[${communities}]]*/ 'communities';
     /*<![CDATA[*/
 
-    console.log(data);
-
     // let the grid know which columns and what data to use
     const gridOptions = {
         columnDefs: columnDefs,

--- a/practiceapp/src/main/resources/templates/posts.html
+++ b/practiceapp/src/main/resources/templates/posts.html
@@ -15,21 +15,20 @@
 
   // specify the columns
   const columnDefs = [
-    { field: "Content" , autoHeight: true, wrapText: true, resizable: true, flex: 8},
+    { field: "Content" , autoHeight: true, wrapText: true, resizable: true, flex: 3},
+    { field: "Author", autoHeight: true, wrapText: true, resizable: true, flex: 1},
     { field: "Date", autoHeight: true, wrapText: true, resizable: true, flex: 2},
-    { field: "Location", autoHeight: true, wrapText: true, resizable: true, flex: 6},
-    { field: "Author", autoHeight: true, wrapText: true, resizable: true, flex: 3}
+    { field: "Location", autoHeight: true, wrapText: true, resizable: true, flex: 1}
   ];
 
   /*<![CDATA[*/
-  const data = /*[[${posts}]]*/ 'posts';
+  const data = /*[[${rows}]]*/ 'rows';
   /*<![CDATA[*/
-
 
   // let the grid know which columns and what data to use
   const gridOptions = {
       columnDefs: columnDefs,
-      rowData: data,
+      rowData: JSON.parse(data),
       pagination: true,
       animateRows: true,
       enableCellChangeFlash: true,

--- a/practiceapp/src/test/java/com/practiceapp/practiceapp/controller/community/GetCommunitiesByPublicityControllerTest.java
+++ b/practiceapp/src/test/java/com/practiceapp/practiceapp/controller/community/GetCommunitiesByPublicityControllerTest.java
@@ -63,11 +63,7 @@ public class GetCommunitiesByPublicityControllerTest {
      *  returns public communities as requested
      *
      *  Expected:
-     *              - Return OK-200
-     *              - Calling service to get public communities
-     *              - Return communities as service responded
-     *              - Calling specified method of service exactly once
-     *              - no other methods of the service is called during this test
+     *              - Returning OK-200 and public communities as requested
      *
      */
 
@@ -79,9 +75,6 @@ public class GetCommunitiesByPublicityControllerTest {
 
         JSONAssert.assertEquals(objectMapper.writeValueAsString(List.of(publicCommunity1, publicCommunity2)),
                 result.getResponse().getContentAsString(), false);
-
-        verify(communityService, times(1)).findByPublicity(true);
-        verifyNoMoreInteractions(communityService);
     }
 
 
@@ -90,11 +83,7 @@ public class GetCommunitiesByPublicityControllerTest {
      *  returns private communities as requested
      *
      *  Expected:
-     *              - Return OK-200
-     *              - Calling service to get private communities
-     *              - Return communities as service responded
-     *              - Calling specified method of service exactly once (findByPublicity)
-     *              - no other methods of the service is called during this test
+     *              - Return OK-200 and private communities as requested
      *
      */
 
@@ -106,8 +95,25 @@ public class GetCommunitiesByPublicityControllerTest {
 
         JSONAssert.assertEquals(objectMapper.writeValueAsString(List.of(privateCommunity)),
                 result.getResponse().getContentAsString(), false);
+    }
 
-        verify(communityService, times(1)).findByPublicity(false);
+
+    /**
+     *  Checks whether {@link GetCommunitiesByPublicityController#getCommunitiesByPublicity(boolean)}
+     *  returns public communities as requested
+     *
+     *  Expected:
+     *              - Calling correct methods of the communityService with correct parameter exactly once
+     *
+     */
+
+    @Test
+    void getCommunitiesByPublicity_isCommunityServiceCalledCorrectly() throws Exception {
+        when(communityService.findByPublicity(any(Boolean.class))).thenReturn(List.of(publicCommunity1, publicCommunity2));
+
+        mockMvc.perform(get("/communities/").param("public", "true")).andExpect(status().isOk()).andReturn();
+
+        verify(communityService, times(1)).findByPublicity(true);
         verifyNoMoreInteractions(communityService);
     }
 }

--- a/practiceapp/src/test/java/com/practiceapp/practiceapp/controller/community/GetCommunitiesByPublicityControllerTest.java
+++ b/practiceapp/src/test/java/com/practiceapp/practiceapp/controller/community/GetCommunitiesByPublicityControllerTest.java
@@ -9,11 +9,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,46 +60,54 @@ public class GetCommunitiesByPublicityControllerTest {
 
     /**
      *  Checks whether {@link GetCommunitiesByPublicityController#getCommunitiesByPublicity(boolean)}
-     *  returns communities
+     *  returns public communities as requested
      *
      *  Expected:
      *              - Return OK-200
-     *              - Calling service to get communities
+     *              - Calling service to get public communities
      *              - Return communities as service responded
+     *              - Calling specified method of service exactly once
+     *              - no other methods of the service is called during this test
      *
      */
 
     @Test
-    void getPublicCommunities() throws Exception {
+    void getCommunitiesByPublicity_isPublicCommunitiesReturnedSuccessfully() throws Exception {
         when(communityService.findByPublicity(any(Boolean.class))).thenReturn(List.of(publicCommunity1, publicCommunity2));
 
         MvcResult result = mockMvc.perform(get("/communities/").param("public", "true")).andExpect(status().isOk()).andReturn();
 
         JSONAssert.assertEquals(objectMapper.writeValueAsString(List.of(publicCommunity1, publicCommunity2)),
                 result.getResponse().getContentAsString(), false);
+
+        verify(communityService, times(1)).findByPublicity(true);
+        verifyNoMoreInteractions(communityService);
     }
 
 
     /**
-     *  Checks whether
-     *  {@link GetCommunitiesByPublicityController#getCommunitiesByPublicity(boolean)}
-     *  calls service with correct parameter
+     *  Checks whether {@link GetCommunitiesByPublicityController#getCommunitiesByPublicity(boolean)}
+     *  returns private communities as requested
      *
      *  Expected:
      *              - Return OK-200
-     *              - Calling service for private communities as it is requested
+     *              - Calling service to get private communities
      *              - Return communities as service responded
+     *              - Calling specified method of service exactly once (findByPublicity)
+     *              - no other methods of the service is called during this test
      *
      */
 
     @Test
-    void isServiceCalledCorrectly() throws Exception {
-        when(communityService.findByPublicity(false)).thenReturn(List.of(privateCommunity));
-        when(communityService.findByPublicity(true)).thenReturn(List.of(publicCommunity1));
+    void getCommunitiesByPublicity_isPrivateCommunitiesReturnedSuccessfully() throws Exception {
+        when(communityService.findByPublicity(any(Boolean.class))).thenReturn(List.of(privateCommunity));
 
         MvcResult result = mockMvc.perform(get("/communities/").param("public", "false")).andExpect(status().isOk()).andReturn();
 
         JSONAssert.assertEquals(objectMapper.writeValueAsString(List.of(privateCommunity)),
                 result.getResponse().getContentAsString(), false);
+
+        verify(communityService, times(1)).findByPublicity(false);
+        verifyNoMoreInteractions(communityService);
     }
 }

--- a/practiceapp/src/test/java/com/practiceapp/practiceapp/service/CommunityServiceTest.java
+++ b/practiceapp/src/test/java/com/practiceapp/practiceapp/service/CommunityServiceTest.java
@@ -67,15 +67,10 @@ public class CommunityServiceTest {
 
 
     /**
-     *  Checks whether
-     *  {@link CommunityService#createCommunity(CommunityEntity)}
-     *  calls CommunityRepository and returns respond of the repository without error
+     *  Checks {@link CommunityService#createCommunity(CommunityEntity)}
      *
      *  Expected:
      *              - Return community as repository {@link CommunityRepository#save(Object)} responded
-     *              - Calling repository with correct parameter (save)
-     *              - Calling specified method of repository exactly once
-     *              - No other methods of the repository is called during this test
      *
      */
     @Test
@@ -85,31 +80,52 @@ public class CommunityServiceTest {
         CommunityEntity response = communityService.createCommunity(publicCommunity);
 
         assertEquals(publicCommunity, response);
+    }
+
+    /**
+     *  Checks {@link CommunityService#createCommunity(CommunityEntity)}
+     *
+     *  Expected:
+     *              - Calling correct methods of repository with correct parameter exactly once
+     */
+    @Test
+    void createCommunity_isCommunityRepositoryCalledCorrectly() {
+
+        when(communityRepository.save(any(CommunityEntity.class))).thenReturn(publicCommunity);
+        communityService.createCommunity(publicCommunity);
 
         verify(communityRepository, times(1)).save(publicCommunity);
         verifyNoMoreInteractions(communityRepository);
-
     }
 
 
     /**
-     *  Checks whether 
-     *  {@link CommunityService#findByPublicity(Boolean)}
-     *  calls CommunityRepository and returns respond of the repository without error
+     *  Checks {@link CommunityService#findByPublicity(Boolean)}
      *
      *  Expected:
      *              - Return community as repository {@link CommunityRepository#findAllByPublicity(Boolean)} responded
-     *              - Calling specified method of the repository with correct parameter (findAllByPublicity)
-     *              - Calling specified method of repository exactly once
-     *              - No other methods of the repository is called during this test
      */
     @Test
-    void findByPublicity_isCommunitiesReturnedCorrectly() {
+    void findByPublicity_isCommunitiesReturnedSuccessfully() {
 
         when(communityRepository.findAllByPublicity(any(Boolean.class))).thenReturn(List.of(publicCommunity));
         List<CommunityEntity> communityEntities = communityService.findByPublicity(publicCommunity.isPublicity());
 
         assertEquals(List.of(publicCommunity), communityEntities);
+    }
+
+
+    /**
+     *  Checks {@link CommunityService#findByPublicity(Boolean)}
+     *
+     *  Expected:
+     *              - Calling correct methods of repository with correct parameter exactly once
+     */
+    @Test
+    void findByPublicity_isCommunityRepositoryCalledCorrectly() {
+
+        when(communityRepository.findAllByPublicity(any(Boolean.class))).thenReturn(List.of(publicCommunity));
+        communityService.findByPublicity(publicCommunity.isPublicity());
 
         verify(communityRepository, times(1)).findAllByPublicity(publicCommunity.isPublicity());
         verifyNoMoreInteractions(communityRepository);
@@ -117,15 +133,10 @@ public class CommunityServiceTest {
 
 
     /**
-     *  Checks whether
-     *  {@link CommunityService#getByName(String)}
-     *  works properly
+     *  Checks {@link CommunityService#getByName(String)}
      *
      *  Expected:
      *              - Return community entity as {@link CommunityRepository#getByName(String)} responded
-     *              - Calling specified method of the repository with correct parameter
-     *              - Calling specified method of the repository exactly once
-     *              - No other methods of the repository is called during this test
      *
      */
     @Test
@@ -135,6 +146,21 @@ public class CommunityServiceTest {
         CommunityEntity response = communityService.getByName(publicCommunity.getName());
 
         assertEquals(publicCommunity, response);
+    }
+
+
+    /**
+     *  Checks {@link CommunityService#getByName(String)}
+     *
+     *  Expected:
+     *              - Calling correct methods of repository with correct parameter exactly once
+     *
+     */
+    @Test
+    void getByName_isCommunityRepositoryCalledCorrectly() {
+        when(communityRepository.getByName(any(String.class))).thenReturn(publicCommunity);
+
+        communityService.getByName(publicCommunity.getName());
 
         verify(communityRepository, times(1)).getByName(publicCommunity.getName());
         verifyNoMoreInteractions(communityRepository);
@@ -142,16 +168,11 @@ public class CommunityServiceTest {
 
 
     /**
-     *  Checks whether
-     *  {@link CommunityService#exists(String)}
-     *  works properly
+     *  Checks {@link CommunityService#exists(String)}
      *
      *  Expected:
      *              - Return true since {@link CommunityRepository#getByName(String)} responds as
      *                there is no community with specified name.
-     *              - Calling specified method of the repository with correct parameter
-     *              - Calling specified method of the repository exactly once
-     *              - No other methods of the repository is called during this test
      *
      */
     @Test
@@ -161,23 +182,15 @@ public class CommunityServiceTest {
         Boolean response = communityService.exists("new community name");
 
         assertEquals(false, response);
-
-        verify(communityRepository, times(1)).getByName("new community name");
-        verifyNoMoreInteractions(communityRepository);
     }
 
 
     /**
-     *  Checks whether
-     *  {@link CommunityService#exists(String)}
-     *  works properly
+     *  Checks {@link CommunityService#exists(String)}
      *
      *  Expected:
      *              - Return false since {@link CommunityRepository#getByName(String)}
      *                returns community
-     *              - Calling specified method of the repository with correct parameter
-     *              - Calling specified method of the repository exactly once
-     *              - No other methods of the repository is called during this test
      */
     @Test
     void exists_isTrueWhenExists() {
@@ -186,11 +199,42 @@ public class CommunityServiceTest {
         Boolean response = communityService.exists(publicCommunity.getName());
 
         assertEquals(true, response);
+    }
 
-        verify(communityRepository, times(1)).getByName(publicCommunity.getName());
+
+    /**
+     *  Checks {@link CommunityService#exists(String)}
+     *
+     *  Expected:
+     *              - Calling correct methods of the repository with correct parameter exactly once
+     *
+     */
+    @Test
+    void exists_isCommunityRepositoryCalledCorrectly() {
+        when(communityRepository.getByName(any(String.class))).thenReturn(null);
+
+        communityService.exists("new community name");
+
+        verify(communityRepository, times(1)).getByName("new community name");
         verifyNoMoreInteractions(communityRepository);
     }
 
+
+
+    /**
+     *  Checks {@link CommunityService#getPosts(String)}
+     *
+     *  Expected:
+     *              - Return list of posts as {@link CommunityRepository#getByName(String)}.getPosts() responded
+     */
+    @Test
+    void getPosts_isPostsReturnedSuccessfully() {
+        when(communityRepository.getByName(any(String.class))).thenReturn(communityWithPost);
+
+        List<PostEntity> response = communityService.getPosts(communityWithPost.getName());
+
+        assertEquals(communityWithPost.getPosts(), response);
+    }
 
 
     /**
@@ -199,18 +243,13 @@ public class CommunityServiceTest {
      *  works properly
      *
      *  Expected:
-     *              - Return list of posts as {@link CommunityRepository#getByName(String)}.getPosts() responded
-     *              - Calling specified method of the repository with correct parameter
-     *              - Calling specified method of the repository exactly once
-     *              - No other methods of the repository is called during this test
+     *              - Calling correct methods of the repository with correct parameter exactly once
      */
     @Test
-    void getPosts() {
+    void getPosts_isCommunityRepositoryCalledCorrectly() {
         when(communityRepository.getByName(any(String.class))).thenReturn(communityWithPost);
 
-        List<PostEntity> response = communityService.getPosts(communityWithPost.getName());
-
-        assertEquals(communityWithPost.getPosts(), response);
+        communityService.getPosts(communityWithPost.getName());
 
         verify(communityRepository, times(1)).getByName(communityWithPost.getName());
         verifyNoMoreInteractions(communityRepository);
@@ -220,24 +259,36 @@ public class CommunityServiceTest {
     // BELOW FUNCTIONS TESTS SERVICE FUNCTIONS RELATED TO THIRD-PARTY APIs:
 
     /**
-     *  Checks whether
-     *  {@link CommunityService#detectLanguage(String)}
-     *  works properly
+     *  Checks {@link CommunityService#detectLanguage(String)}
      *
      *  Expected:
      *              - Return language code as
      *                {@link DetectLanguageApi#detectLanguage(String)} responded
-     *              - Calling specified method of the DetectLanguageApi with correct parameter
-     *              - Calling specified method of the DetectLanguageApi exactly once
-     *              - No other methods of the DetectLanguageApi is called during this test
      */
     @Test
-    void detectLanguage() {
+    void detectLanguage_isDetectedLanguageReturnedSuccessfully() {
 
         when(detectLanguageApi.detectLanguage(any(String.class))).thenReturn("en");
 
         String language = communityService.detectLanguage(publicCommunity.getDescription());
         assertEquals("en", language);
+    }
+
+
+    /**
+     *  Checks whether
+     *  {@link CommunityService#detectLanguage(String)}
+     *  works properly
+     *
+     *  Expected:
+     *              - Calling correct methods of the detectLanguageApi with correct parameter exactly once
+     */
+    @Test
+    void detectLanguage_isApiCalledCorrectly() {
+
+        when(detectLanguageApi.detectLanguage(any(String.class))).thenReturn("en");
+
+        communityService.detectLanguage(publicCommunity.getDescription());
 
         verify(detectLanguageApi, times(1)).detectLanguage(publicCommunity.getDescription());
         verifyNoMoreInteractions(detectLanguageApi);

--- a/practiceapp/src/test/java/com/practiceapp/practiceapp/service/CommunityServiceTest.java
+++ b/practiceapp/src/test/java/com/practiceapp/practiceapp/service/CommunityServiceTest.java
@@ -16,7 +16,8 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @WebMvcTest(CommunityService.class)
 public class CommunityServiceTest {
@@ -72,35 +73,21 @@ public class CommunityServiceTest {
      *
      *  Expected:
      *              - Return community as repository {@link CommunityRepository#save(Object)} responded
+     *              - Calling repository with correct parameter (save)
+     *              - Calling specified method of repository exactly once
+     *              - No other methods of the repository is called during this test
      *
      */
     @Test
-    void createCommunity_isCreatedCommunityReturnedCorrectly() {
+    void createCommunity_isCommunityCreatedSuccessfully() {
 
         when(communityRepository.save(any(CommunityEntity.class))).thenReturn(publicCommunity);
         CommunityEntity response = communityService.createCommunity(publicCommunity);
 
         assertEquals(publicCommunity, response);
 
-    }
-
-
-    /**
-     *  Checks whether
-     *  {@link CommunityService#createCommunity(CommunityEntity)}
-     *  calls repository with correct parameters
-     *
-     *  Expected:
-     *              - Call repository {@link CommunityRepository#save(Object)} with specified community entity
-     *
-     */
-    @Test
-    void createCommunity_isRepositoryCalledCorrectly() {
-
-        when(communityRepository.save(any(CommunityEntity.class))).thenAnswer(i -> i.getArguments()[0]);
-        CommunityEntity response = communityService.createCommunity(publicCommunity);
-
-        assertEquals(publicCommunity, response);
+        verify(communityRepository, times(1)).save(publicCommunity);
+        verifyNoMoreInteractions(communityRepository);
 
     }
 
@@ -112,7 +99,9 @@ public class CommunityServiceTest {
      *
      *  Expected:
      *              - Return community as repository {@link CommunityRepository#findAllByPublicity(Boolean)} responded
-     *
+     *              - Calling specified method of the repository with correct parameter (findAllByPublicity)
+     *              - Calling specified method of repository exactly once
+     *              - No other methods of the repository is called during this test
      */
     @Test
     void findByPublicity_isCommunitiesReturnedCorrectly() {
@@ -121,28 +110,9 @@ public class CommunityServiceTest {
         List<CommunityEntity> communityEntities = communityService.findByPublicity(publicCommunity.isPublicity());
 
         assertEquals(List.of(publicCommunity), communityEntities);
-    }
 
-
-    /**
-     *  Checks whether 
-     *  {@link CommunityService#findByPublicity(Boolean)}
-     *  calls repository with correct parameter
-     *
-     *  Expected:
-     *              - Calling repository with correct parameter (true)
-     *              - Return community as repository {@link CommunityRepository#findAllByPublicity(Boolean)} responded
-     *
-     */
-    @Test
-    void findByPublicity_isRepositoryCalledCorrectly() {
-
-        when(communityRepository.findAllByPublicity(true)).thenReturn(List.of(publicCommunity));
-        when(communityRepository.findAllByPublicity(false)).thenReturn(List.of(publicCommunity));
-
-        List<CommunityEntity> communityEntities = communityService.findByPublicity(publicCommunity.isPublicity());
-
-        assertEquals( publicCommunity.isPublicity(), communityEntities.get(0).isPublicity());
+        verify(communityRepository, times(1)).findAllByPublicity(publicCommunity.isPublicity());
+        verifyNoMoreInteractions(communityRepository);
     }
 
 
@@ -153,15 +123,21 @@ public class CommunityServiceTest {
      *
      *  Expected:
      *              - Return community entity as {@link CommunityRepository#getByName(String)} responded
+     *              - Calling specified method of the repository with correct parameter
+     *              - Calling specified method of the repository exactly once
+     *              - No other methods of the repository is called during this test
      *
      */
     @Test
-    void getByName() {
+    void getByName_isCommunityReturnedSuccessfully() {
         when(communityRepository.getByName(any(String.class))).thenReturn(publicCommunity);
 
         CommunityEntity response = communityService.getByName(publicCommunity.getName());
 
         assertEquals(publicCommunity, response);
+
+        verify(communityRepository, times(1)).getByName(publicCommunity.getName());
+        verifyNoMoreInteractions(communityRepository);
     }
 
 
@@ -173,6 +149,9 @@ public class CommunityServiceTest {
      *  Expected:
      *              - Return true since {@link CommunityRepository#getByName(String)} responds as
      *                there is no community with specified name.
+     *              - Calling specified method of the repository with correct parameter
+     *              - Calling specified method of the repository exactly once
+     *              - No other methods of the repository is called during this test
      *
      */
     @Test
@@ -182,6 +161,9 @@ public class CommunityServiceTest {
         Boolean response = communityService.exists("new community name");
 
         assertEquals(false, response);
+
+        verify(communityRepository, times(1)).getByName("new community name");
+        verifyNoMoreInteractions(communityRepository);
     }
 
 
@@ -193,7 +175,9 @@ public class CommunityServiceTest {
      *  Expected:
      *              - Return false since {@link CommunityRepository#getByName(String)}
      *                returns community
-     *
+     *              - Calling specified method of the repository with correct parameter
+     *              - Calling specified method of the repository exactly once
+     *              - No other methods of the repository is called during this test
      */
     @Test
     void exists_isTrueWhenExists() {
@@ -202,6 +186,9 @@ public class CommunityServiceTest {
         Boolean response = communityService.exists(publicCommunity.getName());
 
         assertEquals(true, response);
+
+        verify(communityRepository, times(1)).getByName(publicCommunity.getName());
+        verifyNoMoreInteractions(communityRepository);
     }
 
 
@@ -213,7 +200,9 @@ public class CommunityServiceTest {
      *
      *  Expected:
      *              - Return list of posts as {@link CommunityRepository#getByName(String)}.getPosts() responded
-     *
+     *              - Calling specified method of the repository with correct parameter
+     *              - Calling specified method of the repository exactly once
+     *              - No other methods of the repository is called during this test
      */
     @Test
     void getPosts() {
@@ -222,6 +211,9 @@ public class CommunityServiceTest {
         List<PostEntity> response = communityService.getPosts(communityWithPost.getName());
 
         assertEquals(communityWithPost.getPosts(), response);
+
+        verify(communityRepository, times(1)).getByName(communityWithPost.getName());
+        verifyNoMoreInteractions(communityRepository);
     }
 
 
@@ -235,7 +227,9 @@ public class CommunityServiceTest {
      *  Expected:
      *              - Return language code as
      *                {@link DetectLanguageApi#detectLanguage(String)} responded
-     *
+     *              - Calling specified method of the DetectLanguageApi with correct parameter
+     *              - Calling specified method of the DetectLanguageApi exactly once
+     *              - No other methods of the DetectLanguageApi is called during this test
      */
     @Test
     void detectLanguage() {
@@ -244,6 +238,10 @@ public class CommunityServiceTest {
 
         String language = communityService.detectLanguage(publicCommunity.getDescription());
         assertEquals("en", language);
+
+        verify(detectLanguageApi, times(1)).detectLanguage(publicCommunity.getDescription());
+        verifyNoMoreInteractions(detectLanguageApi);
+        verifyNoMoreInteractions(communityRepository);
     }
 }
 


### PR DESCRIPTION
- Naming and Javadoc improvements
- Configured the mock service for the _exists_ method in **CreateCommunityControllerTest**
-  Added test for returning 403 when community name is not unique in  **CreateCommunityControllerTest**
- Verified correct methods are called with correct parameters exactly once and no other methods are called during the tests.
- Fixed sending parameter with the redirect in **GetCommunitiesByPublicityViewController**
- Fixed bug in see post functionality: **GetPostsViewController**. and **posts** template _(Fixed casting problem in the controller and data retrieval problem in the template)_