### PR TITLE
Mobile: About and Members Tabs to the Community Detail

### DIFF
--- a/mobile/CmpE451_App/src/component/HomeButton.js
+++ b/mobile/CmpE451_App/src/component/HomeButton.js
@@ -5,7 +5,7 @@ import {IconButton} from 'react-native-paper';
 const HomeButton = ({navigation}) => {
   return (
     <TouchableOpacity
-      onPress={() => navigation.navigate('Home')}
+      onPress={() => navigation.navigate('Main')}
       style={{margin: 0, flex: 1}}>
       <IconButton
         icon="home-circle-outline"

--- a/mobile/CmpE451_App/src/component/UserList.js
+++ b/mobile/CmpE451_App/src/component/UserList.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {Text, Image, StyleSheet, TouchableOpacity, View} from 'react-native';
+
+import {list} from '../theme/styles';
+import {listItem} from '../theme/styles';
+
+export default function TabScreen({users, onPress}) {
+  return (
+    <View>
+      {users.map(user => (
+        <TouchableOpacity
+          onPress={() => {
+            if (onPress) {
+              onPress(user);
+            }
+          }}>
+          <View style={list}>
+            <Image
+              source={{uri: user.profilePhotoUrl.value}}
+              style={styles.image}
+            />
+            <Text style={listItem}>{user.username}</Text>
+          </View>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    margin: 0,
+    paddingBottom: 0,
+  },
+  image: {
+    width: 30,
+    height: 30,
+  },
+});

--- a/mobile/CmpE451_App/src/screen/Communities.js
+++ b/mobile/CmpE451_App/src/screen/Communities.js
@@ -157,7 +157,7 @@ export default function Communities({navigation}) {
   }
 
   const navigate = async () => {
-    navigation.navigate('Home');
+    navigation.navigate('Main');
   };
 
   return (

--- a/mobile/CmpE451_App/src/screen/Community.js
+++ b/mobile/CmpE451_App/src/screen/Community.js
@@ -1,13 +1,22 @@
 import React, {useEffect, useState} from 'react';
-import {View, Image, Text, StyleSheet, ToastAndroid} from 'react-native';
+import {
+  ScrollView,
+  View,
+  Image,
+  Text,
+  StyleSheet,
+  ToastAndroid,
+} from 'react-native';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import {useIsFocused} from '@react-navigation/native';
 import {COLORS} from '../theme/colors';
+import {listItem} from '../theme/styles';
 import ScreenHeader from '../component/ScreenHeader';
 import {IconButton} from 'react-native-paper';
 import {Button} from 'react-native-elements';
 import {PAGE_VARIABLES} from '../constants';
 import * as Client from '../services/BoxyClient';
+import UserList from '../component/UserList';
 
 export default function Community({navigation}) {
   const Tab = createMaterialTopTabNavigator();
@@ -16,10 +25,17 @@ export default function Community({navigation}) {
   const [name, setName] = useState('');
   const [memberCount, setMemberCount] = useState(20);
   const [description, setDescription] = useState('');
+
+  const [members, setMembers] = useState([]);
+  const [moderators, setModerators] = useState([]);
+  const [pendingMembers, setPendingMembers] = useState([]);
+
   const [isPrivate, setIsPrivate] = useState(false);
   const [isMember, setIsMember] = useState(false);
-  const [isModerator, setIsModerator] = useState(true);
+  const [isModerator, setIsModerator] = useState(false);
+  const [isPending, setIsPending] = useState(false);
   const isFocused = useIsFocused();
+
   useEffect(() => {
     async function fetchCommunityDetails() {
       let response = await Client.getCommunityDetail({
@@ -29,11 +45,15 @@ export default function Community({navigation}) {
       if (response.status === 200) {
         setIconUrl(response.data.iconUrl);
         setName(response.data.name);
+        setMemberCount(response.data.memberCount);
         setDescription(response.data.description);
+        setMembers(response.data.members);
+        setModerators(response.data.moderators);
+        setPendingMembers(response.data.pendingMembers);
         setIsPrivate(response.data.isPrivate);
         setIsMember(response.data.isMember);
         setIsModerator(response.data.isModerator);
-        setMemberCount(response.data.memberCount);
+        setIsPending(response.data.isPending);
       } else {
         ToastAndroid.show(response.data.message, ToastAndroid.SHORT);
       }
@@ -47,11 +67,15 @@ export default function Community({navigation}) {
     async function resetStates() {
       setIconUrl('url');
       setName('');
+      setMemberCount(0);
       setDescription('');
+      setMembers([]);
+      setModerators([]);
+      setPendingMembers([]);
       setIsPrivate(false);
       setIsMember(false);
       setIsModerator(false);
-      setMemberCount(0);
+      setIsPending(false);
     }
     if (!isFocused) {
       resetStates();
@@ -72,11 +96,44 @@ export default function Community({navigation}) {
   }
 
   const navigate = async () => {
-    navigation.navigate('Home');
+    navigation.navigate('Main');
   };
 
   function allCommunitesTab() {
     return <View />;
+  }
+
+  function aboutTab() {
+    return (
+      <ScrollView>
+        <View style={styles.container}>
+          <View style={styles.sectionHeaderContainer}>
+            <Text style={styles.sectionText}>About us</Text>
+          </View>
+          <Text style={listItem}>
+            We are a {isPrivate ? 'private' : 'public'} community!
+          </Text>
+          <View style={styles.sectionHeaderContainer}>
+            <Text style={styles.sectionText}>Moderators</Text>
+          </View>
+          <UserList users={moderators} />
+          <View style={styles.sectionHeaderContainer}>
+            <Text style={styles.sectionText}>Need help?</Text>
+          </View>
+          <Text style={listItem}>Message the moderators</Text>
+        </View>
+      </ScrollView>
+    );
+  }
+  function membersTab() {
+    return (
+      <View style={styles.container}>
+        <View style={styles.sectionHeaderContainer}>
+          <Text style={styles.sectionText}>Members</Text>
+        </View>
+        <UserList users={members} />
+      </View>
+    );
   }
   return (
     <View style={styles.container}>
@@ -123,6 +180,8 @@ export default function Community({navigation}) {
       <Text style={styles.text}>{description}</Text>
       <Tab.Navigator>
         <Tab.Screen key={'tab-1'} name={'Posts'} component={allCommunitesTab} />
+        <Tab.Screen key={'tab-2'} name={'About'} component={aboutTab} />
+        <Tab.Screen key={'tab-2'} name={'Members'} component={membersTab} />
       </Tab.Navigator>
     </View>
   );
@@ -219,5 +278,14 @@ const styles = StyleSheet.create({
     fontSize: 10,
     margin: 0,
     paddingVertical: 0,
+  },
+  sectionHeaderContainer: {
+    backgroundColor: '#dddddd',
+    padding: 10,
+  },
+  sectionText: {
+    color: '#555555',
+    fontSize: 13,
+    fontWeight: '500',
   },
 });

--- a/mobile/CmpE451_App/src/screen/CreateCommunity.js
+++ b/mobile/CmpE451_App/src/screen/CreateCommunity.js
@@ -43,7 +43,7 @@ export default function CreateCommunity({navigation}) {
   };
 
   const navigate = async () => {
-    navigation.navigate('Home');
+    navigation.navigate('Main');
   };
 
   return (

--- a/mobile/CmpE451_App/src/screen/CreatePostType.js
+++ b/mobile/CmpE451_App/src/screen/CreatePostType.js
@@ -176,7 +176,7 @@ export default function CreatePostType({navigation}) {
         const status = response.status;
         response = await response.json();
         if (status === 201) {
-          navigation.navigate('Home');
+          navigation.navigate('Main');
         } else {
           ToastAndroid.show(response.message, ToastAndroid.SHORT);
         }

--- a/mobile/CmpE451_App/src/screen/SelectModeratorCommunity.js
+++ b/mobile/CmpE451_App/src/screen/SelectModeratorCommunity.js
@@ -58,7 +58,7 @@ export default function SelectModeratorCommunity({navigation}) {
   };
 
   const navigate = async () => {
-    navigation.navigate('Home');
+    navigation.navigate('Main');
   };
 
   return (

--- a/mobile/CmpE451_App/src/screen/Settings.js
+++ b/mobile/CmpE451_App/src/screen/Settings.js
@@ -8,7 +8,7 @@ import ScreenHeader from '../component/ScreenHeader';
 
 export default function Settings({navigation, route}) {
   const navigate = async () => {
-    navigation.navigate('Home');
+    navigation.navigate('Main');
   };
 
   return (

--- a/mobile/CmpE451_App/src/theme/styles.js
+++ b/mobile/CmpE451_App/src/theme/styles.js
@@ -53,8 +53,8 @@ export const list = {
 
 export const listItem = {
   padding: 10,
-  fontSize: 18,
-  height: 60,
+  fontSize: 16,
+  height: 50,
   color: COLORS.textColor,
   textAlignVertical: 'center',
 };


### PR DESCRIPTION
Added **About** and **members** tab to the community page and fixed navigation to the home page.

About tab includes three sections:
* About Us: Info about privacy status of the community
* Moderators: Moderators list
* Need help: text field => "Contact the moderators"

Members tab includes a list of members.



Closes #355 