### PR TITLE
Mobile: Implement Accept&Reject Moderator Requests

### DIFF
--- a/mobile/CmpE451_App/src/screen/Community.js
+++ b/mobile/CmpE451_App/src/screen/Community.js
@@ -56,7 +56,7 @@ export default function Community({navigation}) {
         setIsPrivate(response.data.isPrivate);
         setIsMember(response.data.isMember);
         setIsModerator(response.data.isModerator);
-        setIsPendingMember(response.data.isPending);
+        setIsPendingMember(response.data.isPendingMember);
         setIsPendingModerator(response.data.isPendingModerator);
       } else {
         ToastAndroid.show(response.data.message, ToastAndroid.SHORT);
@@ -142,7 +142,7 @@ export default function Community({navigation}) {
       communityId: PAGE_VARIABLES.communityId,
     });
     if (response.status === 200) {
-      setIsPendingMember(response.data.isPendingModerator);
+      setIsPendingModerator(response.data.isPendingModerator);
       setPendingModerators(response.data.pendingModerators);
     } else {
       ToastAndroid.show(response.data.message, ToastAndroid.SHORT);
@@ -209,14 +209,13 @@ export default function Community({navigation}) {
   const navigate = async () => {
     navigation.navigate('Main');
   };
-
-  const navigatePendingMembers = () => {
+  const navigatePendingRequests = () => {
     navigation.navigate('PendingRequests', {
       pendingMembers: pendingMembers,
+      pendingModerators: pendingModerators,
       communityId: PAGE_VARIABLES.communityId,
     });
   };
-
   const navigateUpdateCommunity = () => {
     navigation.navigate('UpdateCommunity', {
       name: name,
@@ -229,7 +228,6 @@ export default function Community({navigation}) {
   function allCommunitesTab() {
     return <View />;
   }
-
   function aboutTab() {
     return (
       <ScrollView>
@@ -283,7 +281,7 @@ export default function Community({navigation}) {
           <View style={{flexDirection: 'row'}}>
             <IconButton
               icon="bell"
-              onPress={() => navigatePendingMembers()}
+              onPress={() => navigatePendingRequests()}
               size={22}
               color="white"
               style={{marginHorizontal: 0}}

--- a/mobile/CmpE451_App/src/screen/PendingRequests.js
+++ b/mobile/CmpE451_App/src/screen/PendingRequests.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState} from 'react';
 import {Text, StyleSheet, ToastAndroid, View} from 'react-native';
 import {createMaterialTopTabNavigator} from '@react-navigation/material-top-tabs';
 import UserList from '../component/UserList';
@@ -8,8 +8,10 @@ import * as client from '../services/BoxyClient';
 
 export default function PendingRequests({navigation, route}) {
   const Tab = createMaterialTopTabNavigator();
-  let {pendingMembers, communityId} = route.params;
+  let {pendingMembers, communityId, pendingModerators} = route.params;
   const [pendingMemberList, setPendingMemberList] = useState(pendingMembers);
+  const [pendingModeratorList, setPendingModeratorList] =
+    useState(pendingModerators);
 
   async function acceptPendingMember(userId) {
     let response = await client.acceptJoinRequest({
@@ -37,6 +39,32 @@ export default function PendingRequests({navigation, route}) {
     }
   }
 
+  async function acceptPendingModerator(userId) {
+    let response = await client.acceptJoinModeratorsRequest({
+      communityId: communityId,
+      userId: userId,
+    });
+    if (response.status === 200) {
+      ToastAndroid.show(response.data.message, ToastAndroid.SHORT);
+      setPendingModeratorList(response.data.pendingMembers);
+    } else {
+      ToastAndroid.show(response.data.message, ToastAndroid.SHORT);
+    }
+  }
+
+  async function rejectPendingModerator(userId) {
+    let response = await client.rejectJoinModeratorsRequest({
+      communityId: communityId,
+      userId: userId,
+    });
+    if (response.status === 200) {
+      ToastAndroid.show(response.data.message, ToastAndroid.SHORT);
+      setPendingModeratorList(response.data.pendingMembers);
+    } else {
+      ToastAndroid.show(response.data.message, ToastAndroid.SHORT);
+    }
+  }
+
   function joinCommunityRequestsTab() {
     return (
       <UserList
@@ -57,6 +85,26 @@ export default function PendingRequests({navigation, route}) {
     );
   }
 
+  function joinModeratorsRequestsTab() {
+    return (
+      <UserList
+        users={pendingModeratorList}
+        icons={[
+          {
+            name: 'check-circle-outline',
+            iconColor: 'green',
+            onPress: acceptPendingModerator,
+          },
+          {
+            name: 'close-circle-outline',
+            iconColor: 'red',
+            onPress: rejectPendingModerator,
+          },
+        ]}
+      />
+    );
+  }
+
   return (
     <View style={styles.container}>
       <ScreenHeader
@@ -69,6 +117,11 @@ export default function PendingRequests({navigation, route}) {
           key={'tab-1'}
           name={'Join Requests'}
           component={joinCommunityRequestsTab}
+        />
+        <Tab.Screen
+          key={'tab-2'}
+          name={'Moderator Requests'}
+          component={joinModeratorsRequestsTab}
         />
       </Tab.Navigator>
     </View>

--- a/mobile/CmpE451_App/src/services/BoxyClient.js
+++ b/mobile/CmpE451_App/src/services/BoxyClient.js
@@ -252,6 +252,56 @@ export const rejectJoinRequest = async ({communityId, userId}) => {
     });
 };
 
+export const acceptJoinModeratorsRequest = async ({communityId, userId}) => {
+  return fetch(
+    BASE_URL +
+      'communities/join/moderators/approve?communityId=' +
+      communityId +
+      '&userId=' +
+      userId,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Platform': 'ANDROID',
+        Authorization: await getToken(),
+      },
+    },
+  )
+    .then(response => {
+      return returnResponse(response);
+    })
+    .catch(error => {
+      console.info(error);
+      ToastAndroid.show(TEXT.networkError, ToastAndroid.SHORT);
+    });
+};
+
+export const rejectJoinModeratorsRequest = async ({communityId, userId}) => {
+  return fetch(
+    BASE_URL +
+      'communities/join/moderators/reject?communityId=' +
+      communityId +
+      '&userId=' +
+      userId,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Platform': 'ANDROID',
+        Authorization: await getToken(),
+      },
+    },
+  )
+    .then(response => {
+      return returnResponse(response);
+    })
+    .catch(error => {
+      console.info(error);
+      ToastAndroid.show(TEXT.networkError, ToastAndroid.SHORT);
+    });
+};
+
 export const kickMember = async ({communityId, userId}) => {
   return fetch(
     BASE_URL +


### PR DESCRIPTION
Implemented accept/reject community moderator requests for the moderators.
* Added new tab to pending requests screen. The page is accessible from the community detail page by clicking the notification icon. 
* Implemented handlers to accept or reject the pending requests. 