### PR TITLE
Backend: Allow empty search and return post type name

### DIFF
--- a/backend/src/services/post.service.js
+++ b/backend/src/services/post.service.js
@@ -216,7 +216,7 @@ exports.search = async ({ token, communityId, tag, postTypeId, sortBy }) => {
     throw new ApiError(httpStatus.NOT_FOUND, 'Community does not exist');
   }
   let posts = [];
-  if (tag) {
+  if (!postTypeId) {
     posts = await Post.find({
       $and: [{ community: community._id }, { 'tags.name': { $regex: tag, $options: 'i' } }],
     })

--- a/backend/src/services/post.service.js
+++ b/backend/src/services/post.service.js
@@ -14,7 +14,7 @@ exports.getPosts = async ({ token, communityId, sortBy }) => {
     community: community._id,
   })
     .sort({ [sortBy]: -1 })
-    .populate(['creator'])
+    .populate(['creator', 'postType'])
     .lean();
   return formatters.formatPosts(
     posts.map((p) => ({ ...p, community })),
@@ -94,7 +94,7 @@ exports.createPost = async ({
 };
 
 exports.getPostDetail = async ({ token, communityId, postId }) => {
-  const post = await Post.findById(postId).populate(['creator', 'community']).lean();
+  const post = await Post.findById(postId).populate(['creator', 'community', 'postType']).lean();
   if (!post) {
     throw new ApiError(httpStatus.NOT_FOUND, 'Post does not exist');
   }
@@ -117,7 +117,7 @@ exports.getPostDetail = async ({ token, communityId, postId }) => {
 };
 
 exports.likePost = async ({ token, postId }) => {
-  let post = await Post.findById(postId).populate(['creator', 'community']).lean();
+  let post = await Post.findById(postId).populate(['creator', 'community', 'postType']).lean();
   if (!post) {
     throw new ApiError(httpStatus.NOT_FOUND, 'Post does not exist');
   }
@@ -132,7 +132,9 @@ exports.likePost = async ({ token, postId }) => {
       },
     },
     { new: true }
-  );
+  )
+    .populate(['creator', 'community', 'postType'])
+    .lean();
   return formatters.formatPostDetail(post, token.user);
 };
 
@@ -203,7 +205,7 @@ exports.getHomepage = async ({ token }) => {
     },
   })
     .sort({ createdAt: -1 })
-    .populate(['creator', 'community'])
+    .populate(['creator', 'community', 'postType'])
     .lean();
   return formatters.formatPosts(posts, token.user);
 };
@@ -219,7 +221,7 @@ exports.search = async ({ token, communityId, tag, postTypeId, sortBy }) => {
       $and: [{ community: community._id }, { 'tags.name': { $regex: tag, $options: 'i' } }],
     })
       .sort({ [sortBy]: -1 })
-      .populate(['creator'])
+      .populate(['community', 'creator', 'postType'])
       .lean();
   } else {
     const postType = await PostType.findById(postTypeId).lean();
@@ -231,7 +233,7 @@ exports.search = async ({ token, communityId, tag, postTypeId, sortBy }) => {
       postType: postType._id,
     })
       .sort({ [sortBy]: -1 })
-      .populate(['creator'])
+      .populate(['community', 'creator', 'postType'])
       .lean();
   }
   return formatters.formatPosts(

--- a/backend/src/services/postType.service.js
+++ b/backend/src/services/postType.service.js
@@ -69,7 +69,7 @@ exports.getPostTypeDetail = async ({ communityId, postTypeId }) => {
 };
 
 exports.searchPostTypes = async ({ communityId, query }) => {
-  const community = await Community.find(communityId).lean();
+  const community = await Community.findById(communityId).lean();
   if (!community) {
     throw new ApiError(httpStatus.NOT_FOUND, 'Community does not exist');
   }

--- a/backend/src/utils/formatters.js
+++ b/backend/src/utils/formatters.js
@@ -116,6 +116,7 @@ exports.formatPostDetail = function (post, user) {
       id: post.community._id.toString(),
       name: post.community.name,
     },
+    postType: post.postType.name,
     date: moment(post.createdAt).format('MM/DD/YYYY HH:mm'),
     textFieldNames: post.textFields,
     numberFieldNames: post.numberFields,

--- a/backend/src/validations/community.validation.js
+++ b/backend/src/validations/community.validation.js
@@ -69,7 +69,7 @@ exports.updateCommunity = {
 exports.searchCommunity = {
   query: Joi.object()
     .keys({
-      query: Joi.string().required(),
+      query: Joi.string().allow('', null).required(),
     })
     .required(),
 };

--- a/backend/src/validations/post.validation.js
+++ b/backend/src/validations/post.validation.js
@@ -98,8 +98,8 @@ exports.search = {
     .keys({
       communityId: Joi.string().custom(objectId).required(),
       sortBy: Joi.string().valid('createdAt', 'likeCount').default('createdAt'),
-      tag: Joi.string(),
-      postTypeId: Joi.string().custom(objectId),
+      tag: Joi.string().allow('', null),
+      postTypeId: Joi.string().custom(objectId).allow('', null),
     })
     .required(),
 };

--- a/backend/src/validations/postType.validation.js
+++ b/backend/src/validations/postType.validation.js
@@ -38,7 +38,7 @@ exports.searchPostTypes = {
   query: Joi.object()
     .keys({
       communityId: Joi.string().custom(objectId).required(),
-      query: Joi.string().required(),
+      query: Joi.string().allow('', null).required(),
     })
     .required(),
 };

--- a/backend/src/validations/profile.validation.js
+++ b/backend/src/validations/profile.validation.js
@@ -45,7 +45,7 @@ exports.setNotificationId = {
 
 exports.search = {
   query: Joi.object().keys({
-    query: Joi.string().required(),
+    query: Joi.string().allow('', null).required(),
     communityId: Joi.string().custom(objectId),
   }),
 };


### PR DESCRIPTION
Now, all search endpoints:
- Post type search,
- Community search,
- Profile search,
- Post search 
 endpoints allow empty queries and returns corresponding results.

Post Type Name is added to the responses of the endpoints that returns post information.