### PR TITLE
Mobile: Add recommended communities to search page

### DIFF
--- a/mobile/CmpE451_App/src/services/BoxyClient.js
+++ b/mobile/CmpE451_App/src/services/BoxyClient.js
@@ -531,6 +531,24 @@ export const searchUser = async ({query}) => {
     });
 };
 
+export const getRecommendedCommunities = async () => {
+  return fetch(BASE_URL + 'communities/recommend', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Platform': 'ANDROID',
+      Authorization: await getToken(),
+    },
+  })
+    .then(response => {
+      return returnResponse(response);
+    })
+    .catch(error => {
+      console.info(error);
+      ToastAndroid.show(TEXT.networkError, ToastAndroid.SHORT);
+    });
+};
+
 const returnResponse = async response => {
   const statusCode = response.status;
   response = await response.json();


### PR DESCRIPTION
**Recommend communities** are designed and added to the search page. 
Implemented client method to send _getRecommendedCommunities_ request.

Recommended communities are listed if not text is typed into the search bar and the community option is selected on the search page.  If text input is not an empty string, it sends the search query to the backend and gets corresponding search results.

Search results navigate to the corresponding community detail page.


Closes #463 