### PR TITLE
Mobile: Recommend Users

### DIFF
--- a/mobile/CmpE451_App/src/screen/OtherUserProfile.js
+++ b/mobile/CmpE451_App/src/screen/OtherUserProfile.js
@@ -56,11 +56,8 @@ export default function OtherUserProfile({navigation, route}) {
       <SafeAreaView style={styles.container}>
         <ScrollView showsVerticalScrollIndicator={false}>
           <View style={styles.titleBar}>
-            <TouchableOpacity onPress={() => navigation.navigate('Community')}>
-              <Ionicons
-                name="ios-arrow-back"
-                size={24}
-                color="#52575D"></Ionicons>
+            <TouchableOpacity onPress={navigation.goBack}>
+              <Ionicons name="ios-arrow-back" size={24} color="#52575D" />
             </TouchableOpacity>
           </View>
           <View style={{alignSelf: 'center'}}>
@@ -71,7 +68,8 @@ export default function OtherUserProfile({navigation, route}) {
                     uri: profileImageUrl,
                   }}
                   style={styles.image}
-                  resizeMode="center"></Image>
+                  resizeMode="center"
+                />
               </View>
             ) : (
               <IconButton

--- a/mobile/CmpE451_App/src/screen/Search.js
+++ b/mobile/CmpE451_App/src/screen/Search.js
@@ -94,17 +94,19 @@ export default function Search({navigation}) {
   };
 
   const handleRecommendation = async () => {
+    let response;
     if (isCommunitySearch) {
       setResultsTitle('Recommended Communities');
-      let response = await client.getRecommendedCommunities();
-      const status = response.status;
-      if (status == 200) {
-        setSearchResults(response.data);
-      } else {
-        ToastAndroid.show(response.data.message, ToastAndroid.SHORT);
-      }
+      response = await client.getRecommendedCommunities();
     } else {
       setResultsTitle('Recommended Users');
+      response = await client.getRecommendedUsers();
+    }
+    const status = response.status;
+    if (status == 200) {
+      setSearchResults(response.data);
+    } else {
+      ToastAndroid.show(response.data.message, ToastAndroid.SHORT);
     }
   };
 
@@ -133,7 +135,7 @@ export default function Search({navigation}) {
           }}
         />
       </View>
-      <View style={{padding: 5, width:'100%'}}>
+      <View style={{padding: 5, width: '100%'}}>
         <Text> {resultsTitle} </Text>
       </View>
       {isCommunitySearch ? (

--- a/mobile/CmpE451_App/src/services/BoxyClient.js
+++ b/mobile/CmpE451_App/src/services/BoxyClient.js
@@ -549,6 +549,24 @@ export const getRecommendedCommunities = async () => {
     });
 };
 
+export const getRecommendedUsers = async () => {
+  return fetch(BASE_URL + 'profile/recommend', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Platform': 'ANDROID',
+      Authorization: await getToken(),
+    },
+  })
+    .then(response => {
+      return returnResponse(response);
+    })
+    .catch(error => {
+      console.info(error);
+      ToastAndroid.show(TEXT.networkError, ToastAndroid.SHORT);
+    });
+};
+
 const returnResponse = async response => {
   const statusCode = response.status;
   response = await response.json();


### PR DESCRIPTION
**Recommend users** are designed and added to the search page.
Implemented client method to send _getRecommendedUsers_ request.

Recommended users are listed if no text is typed into the search bar and the user option is selected on the search page. If text input is not an empty string, it sends the search query to the backend and gets corresponding search results.

Search results navigate to the corresponding user profile page.

Closes #464 