### PR TITLE
Mobile: Update the name of the date field in comments

### DIFF
--- a/mobile/CmpE451_App/src/component/PostDetail.js
+++ b/mobile/CmpE451_App/src/component/PostDetail.js
@@ -419,7 +419,7 @@ export default function PostDetail({
               <Comment
                 id={item.id}
                 user={item.user}
-                date={item.date}
+                date={item.createdAt}
                 content={item.text}
               />
             )}


### PR DESCRIPTION
The date field has already been added to the comments, but the name of the field is returned differently by the backend. Updated the name accordingly.

Closes #530 